### PR TITLE
t194: jakku: add sdcard support on sdhci@3440000

### DIFF
--- a/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-p3668-common.dtsi
+++ b/nvidia/platform/t19x/jakku/kernel-dts/common/tegra194-p3668-common.dtsi
@@ -268,6 +268,15 @@
 		status = "okay";
 	};
 
+	sdhci_sd_ext: sdhci@3440000 {
+		mmc-ocr-mask = <0x0>;
+		nvidia,vmmc-always-on;
+		nvidia,vqmmc-always-on;
+		vmmc-supply = <&battery_reg>;
+		vqmmc-supply = <&battery_reg>;
+		status = "okay";
+	};
+
 	mipical@3990000 {
 		status = "okay";
 	};


### PR DESCRIPTION
This is to backport sdcard support to r32.4 kernel